### PR TITLE
fix correlations with other plugins

### DIFF
--- a/src/UI/SlateLoaderDetector.php
+++ b/src/UI/SlateLoaderDetector.php
@@ -10,8 +10,6 @@ use ILIAS\UI\Implementation\Render\ComponentRenderer;
 use ILIAS\UI\Renderer;
 use ilPluginAdmin;
 use Pimple\Container;
-use ReflectionException;
-use ReflectionMethod;
 
 /**
  * Class SlateLoaderDetector

--- a/src/UI/SlateLoaderDetector.php
+++ b/src/UI/SlateLoaderDetector.php
@@ -67,18 +67,10 @@ class SlateLoaderDetector extends AbstractLoaderDetector
                 continue;
             }
             $class = 'il' . $plugin['name'] . 'Plugin';
-            try {
-                $reflector = new ReflectionMethod($class, 'exchangeUIRendererAfterInitialization');
-            } catch (ReflectionException $e) {
-                continue;
-            }
             $class = new $class();
-            if ($reflector->class === get_class($class)) {
-                $RenderClass = $class->exchangeUIRendererAfterInitialization($DIC);
-                $newRenderer = $RenderClass()->getRendererFor($component);
-                if ($newRenderer !== parent::getRendererFor($component, $contexts)) {
-                    return $newRenderer;
-                }
+            $RenderClosure = $class->exchangeUIRendererAfterInitialization($DIC);
+            if ($RenderClosure !== $DIC->raw('ui.renderer')) {
+                return $RenderClosure()->getRendererFor($component);
             }
         }
 


### PR DESCRIPTION
ILIAS atm does not handle renderer exchange by multiple plugins. Therefore only the renderers of the first plugin will be applied (which is the one least called by the exchanger)

This PR should solve correlations with other UI Plugins which also use the ILIAS 6 renderer exchange, when the UserTakeOver-Plugin is the first applied/last exchanged plugin.
